### PR TITLE
Allow :headers option to send custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ The following options are available:
 | Option | Description | Default |
 | :----- | :---------- | :------ |
 | `access_token` | Uses this token while making requests through `GraphQLDocs::Client`. | `nil` |
+| `headers` | Uses this headers while making requests through `GraphQLDocs::Client`. | `nil` |
 | `login` | Uses this login while making requests through `GraphQLDocs::Client`. | `nil` |
 | `password` | Uses this password while making requests through `GraphQLDocs::Client`. | `nil` |
 | `path` | `GraphQLDocs::Client` loads a JSON file found at this location, representing the response from an introspection query. | `nil` |

--- a/lib/graphql-docs/client.rb
+++ b/lib/graphql-docs/client.rb
@@ -20,7 +20,8 @@ module GraphQLDocs
       @access_token = options[:access_token]
 
       @url = options[:url]
-      @faraday = Faraday.new(url: @url)
+      @headers = options[:headers]
+      @faraday = Faraday.new(url: @url, headers: @headers)
 
       if @login && @password
         @faraday.basic_auth(@login, @password)

--- a/test/graphql-docs/client_test.rb
+++ b/test/graphql-docs/client_test.rb
@@ -52,4 +52,16 @@ class ClientTest < Minitest::Test
                                 'User-Agent'=>'Faraday v0.9.2' },
                       body: "{ \"query\": \"#{GraphQL::Introspection::INTROSPECTION_QUERY.gsub("\n", '')}\" }"
   end
+
+  def test_that_it_makes_requests_with_custom_headers
+    client = GraphQLDocs::Client.new(url: @url, headers: {'X-Api-Token' => '87614b09dd141c22800f96f11737ade5226d7ba8'})
+    client.fetch
+    assert_requested :post, @url,
+                      headers: {'Accept'=>'*/*', \
+                                'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', \
+                                'X-Api-Token'=>'87614b09dd141c22800f96f11737ade5226d7ba8',
+                                'Content-Type'=>'application/json',
+                                'User-Agent'=>'Faraday v0.9.2' },
+                      body: "{ \"query\": \"#{GraphQL::Introspection::INTROSPECTION_QUERY.gsub("\n", '')}\" }"
+  end
 end


### PR DESCRIPTION
Hello. Thank you for the useful gem!

Occasionally, I have to pass some custom headers such as `X-Api-Token: ....` or `Authorization: Bearer ....` to GraphQL servers. So I'd like to add the `:headers` option.