### PR TITLE
Remove leading spaces when rendering content

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,7 @@ end
 
 task default: :test
 
+desc 'Set up a console'
 task :console do
   require 'pry'
   require 'graphql-docs'
@@ -26,6 +27,7 @@ task :console do
   Pry.start
 end
 
+desc 'Generate the documentation'
 task :generate_sample, [:base_url] do |task, args|
   require 'graphql-docs'
 
@@ -37,6 +39,7 @@ task :generate_sample, [:base_url] do |task, args|
   GraphQLDocs.build(options)
 end
 
+desc 'Generate the documentation and run a web server'
 task sample: [:generate_sample] do
   require 'webrick'
 

--- a/lib/graphql-docs/generator.rb
+++ b/lib/graphql-docs/generator.rb
@@ -188,7 +188,8 @@ module GraphQLDocs
         path = File.join(@options[:output_dir], type, name.downcase)
         FileUtils.mkdir_p(path)
       end
-      contents = @renderer.render(type, name, contents)
+
+      contents = @renderer.render(type, name, contents.gsub(/^\s{4}/m, '  '))
       File.write(File.join(path, 'index.html'), contents) unless contents.nil?
     end
   end


### PR DESCRIPTION
This is misinterpreted by the Commonmark renderer as `pre` tags

Closes https://github.com/gjtorikian/graphql-docs/issues/23.