### PR TITLE
Fix bug with Input Object fields

### DIFF
--- a/lib/graphql-docs/layouts/graphql_input_objects.html
+++ b/lib/graphql-docs/layouts/graphql_input_objects.html
@@ -2,7 +2,7 @@
 
 <%= type[:description] %>
 
-<% unless type[:inputFields].nil? %>
+<% unless type[:input_fields].nil? %>
 
 <h2>Input Fields</h2>
 


### PR DESCRIPTION
The input fields for Input Objects are not currently rendering:

<img width="404" alt="screen shot 2017-12-13 at 12 08 17 pm" src="https://user-images.githubusercontent.com/821071/33951940-5397616e-dffe-11e7-9efe-aa3df36885ed.png">

With the fix:

<img width="370" alt="screen shot 2017-12-13 at 11 43 45 am" src="https://user-images.githubusercontent.com/821071/33951945-5705347a-dffe-11e7-84a7-1ba1c607c4c8.png">
