### PR TITLE
Add support for "notices" to schema members.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The following options are available:
 | `renderer` | The rendering class to use. | `GraphQLDocs::Renderer`
 | `templates` | The templates to use when generating HTML. You may override any of the following keys: `default`, `includes`, `operations`, `objects`, `mutations`, `interfaces`, `enums`, `unions`, `input_objects`, `scalars`. | The defaults are found in _lib/graphql-docs/layouts/_.
 | `landing_pages` | The landing page to use when generating HTML for each type. You may override any of the following keys: `index`, `query`, `object`, `mutation`, `interface`, `enum`, `union`, `input_object`, `scalar`. | The defaults are found in _lib/graphql-docs/layouts/_.
-| `classes` | Additional class names you can provide to certain elements. | The full list is available in _lib/graphql-docs/configuration.rb/_.
+| `classes` | Additional class names you can provide to certain elements. | The full list is available in _lib/graphql-docs/configuration.rb_.
 | `notices` | A proc used to add notices to schema members. See *Customizing Notices* section below. | `nil` |
 
 ### Customizing Notices

--- a/README.md
+++ b/README.md
@@ -119,6 +119,58 @@ The following options are available:
 | `templates` | The templates to use when generating HTML. You may override any of the following keys: `default`, `includes`, `operations`, `objects`, `mutations`, `interfaces`, `enums`, `unions`, `input_objects`, `scalars`. | The defaults are found in _lib/graphql-docs/layouts/_.
 | `landing_pages` | The landing page to use when generating HTML for each type. You may override any of the following keys: `index`, `query`, `object`, `mutation`, `interface`, `enum`, `union`, `input_object`, `scalar`. | The defaults are found in _lib/graphql-docs/layouts/_.
 | `classes` | Additional class names you can provide to certain elements. | The full list is available in _lib/graphql-docs/configuration.rb/_.
+| `notices` | A proc used to add notices to schema members. See *Customizing Notices* section below. | `nil` |
+
+### Customizing Notices
+
+A notice is a block of markdown text that optionally has a title which is displayed above a schema member's description. The
+look of a notice block can be controlled by specifying a custom class for it and then styled via CSS.
+
+The `notices` option allows you to customize the notices that appear for a specific schema member using a proc.
+
+The proc will be called for each schema member and needs to return an array of notices or an empty array if there are none.
+
+A `notice` has the following options:
+
+| Option | Description |
+| :----- | :---------- |
+| `body` | Markdown body of the notice. |
+| `title` | Optional title of the notice |
+| `class` | Optional CSS class for the wrapper `<div>` of the notice |
+| `title_class` | Optional CSS class for the `<span>` of the notice's title |
+
+Example of a `notices` prob that adds a notice to the `TeamDiscussion` type:
+
+```ruby
+options[:notice] = (schema_member_path) -> {
+  notices = []
+
+  if schema_member_path == "TeamDiscussion"
+    notices << {
+      class: "preview-notice",
+      body: "Available via the [Team Discussion](/previews/team-discussion) preview.",
+    }
+  end
+
+  notices
+}
+```
+
+The format of `schema_member_path` is a dot delimited path to the schema member.
+
+For example:
+
+```ruby
+"Author", # an object
+"ExtraInfo" # an interface,
+"Author.socialSecurityNumber" # a field
+"Book.author.includeMiddleInitial" # an argument
+"Likeable" # a union,
+"Cover" # an enum
+"Cover.DIGITAL" # an enum value
+"BookOrder" # an input object
+"Mutation.addLike" # a mutation
+```
 
 ## Development
 

--- a/lib/graphql-docs/configuration.rb
+++ b/lib/graphql-docs/configuration.rb
@@ -51,7 +51,9 @@ module GraphQLDocs
 
       classes: {
         field_entry: '',
-        deprecation_notice: ''
+        deprecation_notice: '',
+        notice: '',
+        notice_title: '',
       }
     }.freeze
   end

--- a/lib/graphql-docs/layouts/graphql_enums.html
+++ b/lib/graphql-docs/layouts/graphql_enums.html
@@ -1,4 +1,4 @@
-# <%= type[:name] %>
+<h1><%= type[:name] %></h1>
 
 <%= type[:description] %>
 

--- a/lib/graphql-docs/layouts/graphql_enums.html
+++ b/lib/graphql-docs/layouts/graphql_enums.html
@@ -1,5 +1,6 @@
 <h1><%= type[:name] %></h1>
 
+<%= include.('notices.html', notices: type[:notices]) %>
 
 <%= type[:description] %>
 

--- a/lib/graphql-docs/layouts/graphql_enums.html
+++ b/lib/graphql-docs/layouts/graphql_enums.html
@@ -1,9 +1,6 @@
 <h1><%= type[:name] %></h1>
 
+
 <%= type[:description] %>
 
-<% unless type[:values].empty? %>
-
 <%= include.('values.html', values: type[:values]) %>
-
-<% end %>

--- a/lib/graphql-docs/layouts/graphql_input_objects.html
+++ b/lib/graphql-docs/layouts/graphql_input_objects.html
@@ -1,5 +1,7 @@
 <h1><%= type[:name] %></h1>
 
+<%= include.('notices.html', notices: type[:notices]) %>
+
 <%= type[:description] %>
 
 <% unless type[:input_fields].nil? %>

--- a/lib/graphql-docs/layouts/graphql_interfaces.html
+++ b/lib/graphql-docs/layouts/graphql_interfaces.html
@@ -1,5 +1,7 @@
 <h1><%= type[:name] %></h1>
 
+<%= include.('notices.html', notices: type[:notices]) %>
+
 <%= type[:description] %>
 
 <% unless type[:implemented_by].empty? %>

--- a/lib/graphql-docs/layouts/graphql_mutations.html
+++ b/lib/graphql-docs/layouts/graphql_mutations.html
@@ -1,5 +1,7 @@
 <h1><%= type[:name] %></h1>
 
+<%= include.('notices.html', notices: type[:notices]) %>
+
 <%= type[:description] %>
 
 <% if !type[:input_fields].empty? %>

--- a/lib/graphql-docs/layouts/graphql_objects.html
+++ b/lib/graphql-docs/layouts/graphql_objects.html
@@ -1,5 +1,7 @@
 <h1><%= type[:name] %></h1>
 
+<%= include.('notices.html', notices: type[:notices]) %>
+
 <%= type[:description] %>
 
 <% unless type[:interfaces].empty? %>

--- a/lib/graphql-docs/layouts/graphql_unions.html
+++ b/lib/graphql-docs/layouts/graphql_unions.html
@@ -1,4 +1,4 @@
-# <%= type[:name] %>
+<h1><%= type[:name] %></h1>
 
 <%= type[:description] %>
 

--- a/lib/graphql-docs/layouts/graphql_unions.html
+++ b/lib/graphql-docs/layouts/graphql_unions.html
@@ -1,9 +1,6 @@
 <h1><%= type[:name] %></h1>
 
+
 <%= type[:description] %>
 
-<% unless type[:possible_types].empty? %>
-
 <%= include.('possible_types.html', possible_types: type[:possible_types]) %>
-
-<% end %>

--- a/lib/graphql-docs/layouts/graphql_unions.html
+++ b/lib/graphql-docs/layouts/graphql_unions.html
@@ -1,5 +1,6 @@
 <h1><%= type[:name] %></h1>
 
+<%= include.('notices.html', notices: type[:notices]) %>
 
 <%= type[:description] %>
 

--- a/lib/graphql-docs/layouts/includes/connections.html
+++ b/lib/graphql-docs/layouts/includes/connections.html
@@ -4,6 +4,7 @@
   <span id="<%= slugify.(connection[:name]) %>" class="field-name connection-name"><%= connection[:name] %> (<a href="<%= base_url %>/<%= connection[:type][:path] %>"><code><%= connection[:type][:info] %></code></a>)</span>
 
   <div class="description-wrapper">
+    <%= include.('notices.html', notices: connection[:notices]) %>
     <p><%= connection[:description] %></p>
 
     <% unless connection[:arguments].empty? %>

--- a/lib/graphql-docs/layouts/includes/fields.html
+++ b/lib/graphql-docs/layouts/includes/fields.html
@@ -11,6 +11,8 @@
     </div>
   <% end %>
 
+  <%= include.('notices.html', notices: field[:notices]) %>
+
   <%= markdownify.(field[:description]) %>
 
   <% unless field[:arguments].empty? %>

--- a/lib/graphql-docs/layouts/includes/input_fields.html
+++ b/lib/graphql-docs/layouts/includes/input_fields.html
@@ -4,6 +4,8 @@
   <span id="<%= slugify.(field[:name]) %>" class="field-name"><%= field[:name] %> (<a href="<%= base_url %>/<%= field[:type][:path] %>"><code><%= field[:type][:info] %></code></a>)</span>
 
   <div class="description-wrapper">
+    <%= include.('notices.html', notices: field[:notices]) %>
+
     <%= field[:description] %>
 
     <% unless field[:arguments].empty? %>

--- a/lib/graphql-docs/layouts/includes/notices.html
+++ b/lib/graphql-docs/layouts/includes/notices.html
@@ -1,7 +1,7 @@
 <% notices.each do |notice| %>
-  <div class="notice <%= notice[:class] %>">
+  <div class="notice <%= classes[:notice] %> <%= notice[:class] %>">
     <% if notice[:title] %>
-      <span class="notice-title <%= notice[:title_class] %>"><%= notice[:title] %></span>
+      <span class="notice-title <%= classes[:notice_title] %> <%= notice[:title_class] %>"><%= notice[:title] %></span>
     <% end %>
     <%= markdownify.(notice[:body]) %>
   </div>

--- a/lib/graphql-docs/layouts/includes/notices.html
+++ b/lib/graphql-docs/layouts/includes/notices.html
@@ -1,0 +1,8 @@
+<% notices.each do |notice| %>
+  <div class="notice <%= notice[:class] %>">
+    <% if notice[:title] %>
+      <span class="notice-title <%= notice[:title_class] %>"><%= notice[:title] %></span>
+    <% end %>
+    <%= markdownify.(notice[:body]) %>
+  </div>
+<% end %>

--- a/lib/graphql-docs/layouts/includes/values.html
+++ b/lib/graphql-docs/layouts/includes/values.html
@@ -5,6 +5,8 @@
   <h4 id="<%= slugify.(value[:name]) %>" class="name"><%= value[:name] %></h4>
 
   <div class="description-wrapper">
+    <%= include.('notices.html', notices: value[:notices]) %>
+
     <% if value[:is_deprecated] %>
       <div class="deprecation-notice <%= classes[:deprecation_notice] %>">
         <span class="deprecation-title">Deprecation notice</span>

--- a/lib/graphql-docs/parser.rb
+++ b/lib/graphql-docs/parser.rb
@@ -8,6 +8,9 @@ module GraphQLDocs
 
     def initialize(schema, options)
       @options = options
+
+      @options[:notices] ||= -> (schema_member_path) { [] }
+
       @schema = GraphQL::Schema.from_definition(schema)
       @processed_schema = {
         operation_types: [],
@@ -25,6 +28,8 @@ module GraphQLDocs
       @schema.types.each_value do |object|
         data = {}
 
+        data[:notices] = @options[:notices].call(object.name)
+
         case object
         when ::GraphQL::ObjectType
           if object.name == 'Query'
@@ -32,7 +37,7 @@ module GraphQLDocs
             data[:description] = object.description
 
             data[:interfaces] = object.interfaces.map(&:name).sort
-            data[:fields], data[:connections] = fetch_fields(object.fields)
+            data[:fields], data[:connections] = fetch_fields(object.fields, object.name)
 
             @processed_schema[:operation_types] << data
           elsif object.name == 'Mutation'
@@ -43,15 +48,17 @@ module GraphQLDocs
 
             object.fields.each_value do |mutation|
               h = {}
+
+              h[:notices] = @options[:notices].call([object.name, mutation.name].join('.'))
               h[:name] = mutation.name
               h[:description] = mutation.description
-              h[:input_fields], _ = fetch_fields(mutation.arguments)
+              h[:input_fields], _ = fetch_fields(mutation.arguments, [object.name, mutation.name].join('.'))
 
               return_type = mutation.type
               if return_type.unwrap.respond_to?(:fields)
-                h[:return_fields], _ = fetch_fields(return_type.unwrap.fields)
+                h[:return_fields], _ = fetch_fields(return_type.unwrap.fields, return_type.name)
               else # it is a scalar return type
-                h[:return_fields], _ = fetch_fields({ "#{return_type.name}" => mutation })
+                h[:return_fields], _ = fetch_fields({ "#{return_type.name}" => mutation }, return_type.name)
               end
 
               @processed_schema[:mutation_types] << h
@@ -61,14 +68,14 @@ module GraphQLDocs
             data[:description] = object.description
 
             data[:interfaces] = object.interfaces.map(&:name).sort
-            data[:fields], data[:connections] = fetch_fields(object.fields)
+            data[:fields], data[:connections] = fetch_fields(object.fields, object.name)
 
             @processed_schema[:object_types] << data
           end
         when ::GraphQL::InterfaceType
           data[:name] = object.name
           data[:description] = object.description
-          data[:fields], data[:connections] = fetch_fields(object.fields)
+          data[:fields], data[:connections] = fetch_fields(object.fields, object.name)
 
           @processed_schema[:interface_types] << data
         when ::GraphQL::EnumType
@@ -77,6 +84,7 @@ module GraphQLDocs
 
           data[:values] = object.values.values.map do |val|
             h = {}
+            h[:notices] = @options[:notices].call([object.name, val.name].join('.'))
             h[:name] = val.name
             h[:description] = val.description
             unless val.deprecation_reason.nil?
@@ -97,7 +105,7 @@ module GraphQLDocs
           data[:name] = object.name
           data[:description] = object.description
 
-          data[:input_fields], _ = fetch_fields(object.input_fields)
+          data[:input_fields], _ = fetch_fields(object.input_fields, object.name)
 
           @processed_schema[:input_object_types] << data
         when ::GraphQL::ScalarType
@@ -132,13 +140,14 @@ module GraphQLDocs
 
     private
 
-    def fetch_fields(object_fields)
+    def fetch_fields(object_fields, parent_path)
       fields = []
       connections = []
 
       object_fields.each_value do |field|
         hash = {}
 
+        hash[:notices] = @options[:notices].call([parent_path, field.name].join('.'))
         hash[:name] = field.name
         hash[:description] = field.description
         if field.respond_to?(:deprecation_reason) && !field.deprecation_reason.nil?


### PR DESCRIPTION
At GitHub we have a few concepts that we'd like to include in our GraphQL documentation. For example, we mark some schema members as deprecated that normally cannot be deprecated as per the spec. We also have the concept of _schema previews_ which allow us to release parts of our schema behind a toggle.

Rather than hardcode these concepts into this documentation generator or having to copy over all the `layouts/` files into our repo, I've added a generic feature to `graphql-docs` that I called: notices.

A notice is a block of markdown text that optionally has a title which is displayed above a schema member's description. The look of a notice block can be controlled by specifying a custom class for it and then styled via CSS.

When the parser converts the schema into an internal representation that is used to render the docs, an optional `notices` proc may be passed. This proc can then be used to add notices to schema members.

@gjtorikian I'm opening this PR to discuss whether you like this direction. It is not ready to be merged yet. 😄 