### PR TITLE
Fix inconsistent styling of type links / input field descriptions

### DIFF
--- a/lib/graphql-docs/layouts/includes/connections.html
+++ b/lib/graphql-docs/layouts/includes/connections.html
@@ -1,7 +1,7 @@
 <% connections.each do |connection| %>
 
 <div class="field-entry <%= classes[:field_entry] %>">
-  <span id="<%= slugify.(connection[:name]) %>" class="field-name connection-name"><%= connection[:name] %> (<a href="<%= base_url %>/<%= connection[:type][:path] %>"><code><%= connection[:type][:info] %></code></a>)</span>
+  <span id="<%= slugify.(connection[:name]) %>" class="field-name connection-name"><%= connection[:name] %> (<code><a href="<%= base_url %>/<%= connection[:type][:path] %>"><%= connection[:type][:info] %></a></code>)</span>
 
   <div class="description-wrapper">
     <%= include.('notices.html', notices: connection[:notices]) %>

--- a/lib/graphql-docs/layouts/includes/input_fields.html
+++ b/lib/graphql-docs/layouts/includes/input_fields.html
@@ -1,7 +1,7 @@
 <% input_fields.each do |field| %>
 
 <div class="field-entry <%= classes[:field_entry] %>">
-  <span id="<%= slugify.(field[:name]) %>" class="field-name"><%= field[:name] %> (<a href="<%= base_url %>/<%= field[:type][:path] %>"><code><%= field[:type][:info] %></code></a>)</span>
+  <span id="<%= slugify.(field[:name]) %>" class="field-name"><%= field[:name] %> (<code><a href="<%= base_url %>/<%= field[:type][:path] %>"><%= field[:type][:info] %></a></code>)</span>
 
   <div class="description-wrapper">
     <%= include.('notices.html', notices: field[:notices]) %>

--- a/lib/graphql-docs/layouts/includes/input_fields.html
+++ b/lib/graphql-docs/layouts/includes/input_fields.html
@@ -6,7 +6,7 @@
   <div class="description-wrapper">
     <%= include.('notices.html', notices: field[:notices]) %>
 
-    <%= field[:description] %>
+    <%= markdownify.(field[:description]) %>
 
     <% unless field[:arguments].empty? %>
       <%= include.('arguments.html', arguments: field[:arguments]) %>


### PR DESCRIPTION
There are a few minor inconsistencies with how we're rendering type links / descriptions for connections and input fields.  These inconsistencies result in styles not being applied properly.

Connections / Input Fields:
* In fields.html, we wrap the link in a `<code>` tag, whereas it's the other way around for connections and input fields.  This isn't apparent in the sample docs page @ https://www.gjtorikian.com/graphql-docs/, but the styles in my project are affected by it.

Input Fields:
* In fields.html, we `markdownify` the field description which results in a `<p>` tag surrounding basic text.  For input fields, we use the raw description which causes the text to be squished vertically.  You can see it if you compare https://www.gjtorikian.com/graphql-docs/object/addcommentpayload/ with https://www.gjtorikian.com/graphql-docs/input_object/addcommentinput/