### PR TITLE
Fix whitespace normalization causing indentation in code blocks to be incorrect

### DIFF
--- a/lib/graphql-docs/generator.rb
+++ b/lib/graphql-docs/generator.rb
@@ -13,14 +13,14 @@ module GraphQLDocs
 
       @renderer = @options[:renderer].new(@parsed_schema, @options)
 
-      @graphql_operation_template = ERB.new(File.read(@options[:templates][:operations]))
-      @graphql_object_template = ERB.new(File.read(@options[:templates][:objects]))
-      @graphql_mutations_template = ERB.new(File.read(@options[:templates][:mutations]))
-      @graphql_interfaces_template = ERB.new(File.read(@options[:templates][:interfaces]))
-      @graphql_enums_template = ERB.new(File.read(@options[:templates][:enums]))
-      @graphql_unions_template = ERB.new(File.read(@options[:templates][:unions]))
-      @graphql_input_objects_template = ERB.new(File.read(@options[:templates][:input_objects]))
-      @graphql_scalars_template = ERB.new(File.read(@options[:templates][:scalars]))
+      @graphql_operation_template = ERB.new(File.read(@options[:templates][:operations]), nil, '<>')
+      @graphql_object_template = ERB.new(File.read(@options[:templates][:objects]), nil, '<>')
+      @graphql_mutations_template = ERB.new(File.read(@options[:templates][:mutations]), nil, '<>')
+      @graphql_interfaces_template = ERB.new(File.read(@options[:templates][:interfaces]), nil, '<>')
+      @graphql_enums_template = ERB.new(File.read(@options[:templates][:enums]), nil, '<>')
+      @graphql_unions_template = ERB.new(File.read(@options[:templates][:unions]), nil, '<>')
+      @graphql_input_objects_template = ERB.new(File.read(@options[:templates][:input_objects]), nil, '<>')
+      @graphql_scalars_template = ERB.new(File.read(@options[:templates][:scalars]), nil, '<>')
     end
 
     def generate
@@ -190,10 +190,6 @@ module GraphQLDocs
         meta, contents = split_into_metadata_and_contents(contents)
         @options = @options.merge(meta)
       end
-
-      # normalize spacing so that CommonMarker doesn't treat it as `pre`
-      contents.gsub!(/^\s*$/, '')
-      contents.gsub!(/^\s{4}/m, '  ')
 
       contents = @renderer.render(contents, type: type, name: name)
       File.write(File.join(path, 'index.html'), contents) unless contents.nil?

--- a/lib/graphql-docs/helpers.rb
+++ b/lib/graphql-docs/helpers.rb
@@ -87,7 +87,7 @@ module GraphQLDocs
 
       contents = File.read(File.join(@options[:templates][:includes], filename))
 
-      @templates[filename] = ERB.new(contents)
+      @templates[filename] = ERB.new(contents, nil, '<>')
     end
 
     def helper_methods


### PR DESCRIPTION
As I understand it, In `GraphQLDocs::Generator` we perform whitespace normalization in order to prevent Markdown from interpreting whitespace at the beginning of an ERB ruby code tag.  For example, this prevents ERB like this:

```erb
    <td>
      <p><%= markdownify.(argument[:description]) %></p>
      <% unless (default_value = argument[:default_value]).nil? %>
        <p>The default value is <code><%= argument[:default_value] %></code>.</p>
      <% end %>
    </td>
```

...from having lines that just have 4 spaces on it (caused by the ERB tags that don't actually output content).  In Markdown, it'll then interpret those spaces and cause problems in the HTML.  The problem with this approach is that it also strips whitespace that is actually important in Markdown.

For example, if I add a code snippet in `landing_pages/index.md` like so:

~~~markdown
---
title: GraphQL documentation
---

# GraphQL Reference

```json
{
  "nest1": {
    "nest2": {
      "nest3": true
    }
  }
}
```
~~~

...it generates the following output:

```html
<pre lang="json"><code>{
  "nest1": {
  "nest2": {
    "nest3": true
  }
  }
}
</code></pre>
```

which looks like this:

![image](https://user-images.githubusercontent.com/6991/37658627-61433294-2c24-11e8-9925-2d216afbfa6a.png)

If we remove the whitespace trimming, the code snippet gets generated as:

```html
<pre lang="json"><code>{
  "nest1": {
    "nest2": {
      "nest3": true
    }
  }
}
</code></pre>
```

which looks like:

![image](https://user-images.githubusercontent.com/6991/37658644-68065674-2c24-11e8-9447-7e7c2340391c.png)

In order to keep the idea behind the whitespace normalization in place but without affecting the actual rendering of the Markdown, I've changed the ERB templates to be created in trim mode.  This will cause any line that contains only a `<%` tag to get trimmed.  I think this was the original goal of the whitespace trimming and appears to allow the scenarios described above to get rendered properly.

There are alternative techniques we could take here to achieve the same goal but this seemed like the least intrusive.

@gjtorikian 