### PR TITLE
Fix argument descriptions containing doubly nested paragraph tags

### DIFF
--- a/lib/graphql-docs/layouts/includes/arguments.html
+++ b/lib/graphql-docs/layouts/includes/arguments.html
@@ -14,7 +14,7 @@
       <code><a href="<%= base_url %>/<%= argument[:type][:path]%>"><%= argument[:type][:info] %></a></code>
     </td>
     <td>
-      <p><%= markdownify.(argument[:description]) %></p>
+      <%= markdownify.(argument[:description]) %>
       <% unless (default_value = argument[:default_value]).nil? %>
         <p>The default value is <code><%= argument[:default_value] %></code>.</p>
       <% end %>


### PR DESCRIPTION
`markdownify` will already wrap argument descriptions in paragraph tags.  However, we've also explicitly wrapped paragraph tags around the `markdownify` content.  This results in two paragraph tags getting rendered.

For an example of this, see: https://www.gjtorikian.com/graphql-docs/object/query/

You'll notice that the description for the "search" connection is rendered with the following html:

```html
<td>
      <p></p>
<p>Returns the first <em>n</em> elements from the list.</p>

    </td>
```

Even though we see 2 separate tags in the html, they're actually nested when we render them in the code (i.e. it looks like `<p><p>Returns the first <em>n</em> elements from the list.</p></p>`).

This just removes the outer paragraph tags instead relying on `markdownify` to do the proper thing.  This more closely matches what we do elsewhere: https://github.com/gjtorikian/graphql-docs/blob/f110f590fb8eaec4a946ccf2707f6cf741e9144c/lib/graphql-docs/layouts/includes/fields.html#L16

@gjtorikian 