### PR TITLE
Fix ERB trim mode to match on %> instead of <%

### DIFF
--- a/lib/graphql-docs/generator.rb
+++ b/lib/graphql-docs/generator.rb
@@ -13,14 +13,14 @@ module GraphQLDocs
 
       @renderer = @options[:renderer].new(@parsed_schema, @options)
 
-      @graphql_operation_template = ERB.new(File.read(@options[:templates][:operations]), nil, '<>')
-      @graphql_object_template = ERB.new(File.read(@options[:templates][:objects]), nil, '<>')
-      @graphql_mutations_template = ERB.new(File.read(@options[:templates][:mutations]), nil, '<>')
-      @graphql_interfaces_template = ERB.new(File.read(@options[:templates][:interfaces]), nil, '<>')
-      @graphql_enums_template = ERB.new(File.read(@options[:templates][:enums]), nil, '<>')
-      @graphql_unions_template = ERB.new(File.read(@options[:templates][:unions]), nil, '<>')
-      @graphql_input_objects_template = ERB.new(File.read(@options[:templates][:input_objects]), nil, '<>')
-      @graphql_scalars_template = ERB.new(File.read(@options[:templates][:scalars]), nil, '<>')
+      @graphql_operation_template = ERB.new(File.read(@options[:templates][:operations]), nil, '>')
+      @graphql_object_template = ERB.new(File.read(@options[:templates][:objects]), nil, '>')
+      @graphql_mutations_template = ERB.new(File.read(@options[:templates][:mutations]), nil, '>')
+      @graphql_interfaces_template = ERB.new(File.read(@options[:templates][:interfaces]), nil, '>')
+      @graphql_enums_template = ERB.new(File.read(@options[:templates][:enums]), nil, '>')
+      @graphql_unions_template = ERB.new(File.read(@options[:templates][:unions]), nil, '>')
+      @graphql_input_objects_template = ERB.new(File.read(@options[:templates][:input_objects]), nil, '>')
+      @graphql_scalars_template = ERB.new(File.read(@options[:templates][:scalars]), nil, '>')
     end
 
     def generate

--- a/lib/graphql-docs/helpers.rb
+++ b/lib/graphql-docs/helpers.rb
@@ -87,7 +87,7 @@ module GraphQLDocs
 
       contents = File.read(File.join(@options[:templates][:includes], filename))
 
-      @templates[filename] = ERB.new(contents, nil, '<>')
+      @templates[filename] = ERB.new(contents, nil, '>')
     end
 
     def helper_methods

--- a/test/graphql-docs/generator_test.rb
+++ b/test/graphql-docs/generator_test.rb
@@ -142,11 +142,25 @@ class GeneratorTest < Minitest::Test
   def test_that_markdown_preserves_whitespace
     options = deep_copy(GraphQLDocs::Configuration::GRAPHQLDOCS_DEFAULTS)
     options[:output_dir] = @output_dir
-    options[:templates][:objects] = File.join(fixtures_dir, 'landing_pages', 'whitespace_template.md')
+    options[:landing_pages][:index] = File.join(fixtures_dir, 'landing_pages', 'whitespace_template.md')
+
     generator = GraphQLDocs::Generator.new(@tiny_results, options)
+    generator.generate
 
-    object = File.read File.join(@output_dir, 'object', 'codeofconduct', 'index.html')
+    contents = File.read File.join(@output_dir, 'index.html')
 
-    assert_match %r{    "nest2": \{}, object
+    assert_match %r{    "nest2": \{}, contents
+  end
+
+  def test_that_empty_lines_trimmed_from_html
+    options = deep_copy(GraphQLDocs::Configuration::GRAPHQLDOCS_DEFAULTS)
+    options[:output_dir] = @output_dir
+
+    generator = GraphQLDocs::Generator.new(@tiny_results, options)
+    generator.generate
+
+    contents = File.read File.join(@output_dir, 'operation', 'query', 'index.html')
+
+    assert_match %r{<td>\s+<p>The code of conduct's key</p>\s+</td>}, contents
   end
 end


### PR DESCRIPTION
This is a follow-up to https://github.com/gjtorikian/graphql-docs/pull/41.  Since the `<%` ERB tags are often indented, they don't get matched by ERB's `<>` trim mode option.  In http://docs.rubydocs.org/ruby-2-4-1/classes/ERB.html#method-c-new, the docs declare that the line must *start* with `<%`.

With this fix, we are matching lines that *end* with `%>`.  This will allow ERB to trim those lines properly.

Definitely double check me on this since I appear to have missed this in the last PR :)

@gjtorikian 