### PR TITLE
Only trim whitespace for html content

### DIFF
--- a/lib/graphql-docs/generator.rb
+++ b/lib/graphql-docs/generator.rb
@@ -13,14 +13,14 @@ module GraphQLDocs
 
       @renderer = @options[:renderer].new(@parsed_schema, @options)
 
-      @graphql_operation_template = ERB.new(File.read(@options[:templates][:operations]), nil, '>')
-      @graphql_object_template = ERB.new(File.read(@options[:templates][:objects]), nil, '>')
-      @graphql_mutations_template = ERB.new(File.read(@options[:templates][:mutations]), nil, '>')
-      @graphql_interfaces_template = ERB.new(File.read(@options[:templates][:interfaces]), nil, '>')
-      @graphql_enums_template = ERB.new(File.read(@options[:templates][:enums]), nil, '>')
-      @graphql_unions_template = ERB.new(File.read(@options[:templates][:unions]), nil, '>')
-      @graphql_input_objects_template = ERB.new(File.read(@options[:templates][:input_objects]), nil, '>')
-      @graphql_scalars_template = ERB.new(File.read(@options[:templates][:scalars]), nil, '>')
+      @graphql_operation_template = ERB.new(File.read(@options[:templates][:operations]))
+      @graphql_object_template = ERB.new(File.read(@options[:templates][:objects]))
+      @graphql_mutations_template = ERB.new(File.read(@options[:templates][:mutations]))
+      @graphql_interfaces_template = ERB.new(File.read(@options[:templates][:interfaces]))
+      @graphql_enums_template = ERB.new(File.read(@options[:templates][:enums]))
+      @graphql_unions_template = ERB.new(File.read(@options[:templates][:unions]))
+      @graphql_input_objects_template = ERB.new(File.read(@options[:templates][:input_objects]))
+      @graphql_scalars_template = ERB.new(File.read(@options[:templates][:scalars]))
     end
 
     def generate
@@ -36,35 +36,35 @@ module GraphQLDocs
       create_graphql_scalar_pages
 
       unless @options[:landing_pages][:index].nil?
-        write_file('static', 'index', File.read(@options[:landing_pages][:index]))
+        write_file('static', 'index', File.read(@options[:landing_pages][:index]), trim: false)
       end
 
       unless @options[:landing_pages][:object].nil?
-        write_file('static', 'object', File.read(@options[:landing_pages][:object]))
+        write_file('static', 'object', File.read(@options[:landing_pages][:object]), trim: false)
       end
 
       unless @options[:landing_pages][:mutation].nil?
-        write_file('operation', 'mutation', File.read(@options[:landing_pages][:mutation]))
+        write_file('operation', 'mutation', File.read(@options[:landing_pages][:mutation]), trim: false)
       end
 
       unless @options[:landing_pages][:interface].nil?
-        write_file('static', 'interface', File.read(@options[:landing_pages][:interface]))
+        write_file('static', 'interface', File.read(@options[:landing_pages][:interface]), trim: false)
       end
 
       unless @options[:landing_pages][:enum].nil?
-        write_file('static', 'enum', File.read(@options[:landing_pages][:enum]))
+        write_file('static', 'enum', File.read(@options[:landing_pages][:enum]), trim: false)
       end
 
       unless @options[:landing_pages][:union].nil?
-        write_file('static', 'union', File.read(@options[:landing_pages][:union]))
+        write_file('static', 'union', File.read(@options[:landing_pages][:union]), trim: false)
       end
 
       unless @options[:landing_pages][:input_object].nil?
-        write_file('static', 'input_object', File.read(@options[:landing_pages][:input_object]))
+        write_file('static', 'input_object', File.read(@options[:landing_pages][:input_object]), trim: false)
       end
 
       unless @options[:landing_pages][:scalar].nil?
-        write_file('static', 'scalar', File.read(@options[:landing_pages][:scalar]))
+        write_file('static', 'scalar', File.read(@options[:landing_pages][:scalar]), trim: false)
       end
 
       if @options[:use_default_styles]
@@ -172,7 +172,7 @@ module GraphQLDocs
       @options.merge(opts).merge(helper_methods)
     end
 
-    def write_file(type, name, contents)
+    def write_file(type, name, contents, trim: true)
       if type == 'static'
         if name == 'index'
           path = @options[:output_dir]
@@ -189,6 +189,12 @@ module GraphQLDocs
         # Split data
         meta, contents = split_into_metadata_and_contents(contents)
         @options = @options.merge(meta)
+      end
+
+      if trim
+        # normalize spacing so that CommonMarker doesn't treat it as `pre`
+        contents.gsub!(/^\s*$/, '')
+        contents.gsub!(/^\s{4}/m, '  ')
       end
 
       contents = @renderer.render(contents, type: type, name: name)

--- a/lib/graphql-docs/helpers.rb
+++ b/lib/graphql-docs/helpers.rb
@@ -87,7 +87,7 @@ module GraphQLDocs
 
       contents = File.read(File.join(@options[:templates][:includes], filename))
 
-      @templates[filename] = ERB.new(contents, nil, '>')
+      @templates[filename] = ERB.new(contents)
     end
 
     def helper_methods

--- a/test/graphql-docs/generator_test.rb
+++ b/test/graphql-docs/generator_test.rb
@@ -152,7 +152,7 @@ class GeneratorTest < Minitest::Test
     assert_match %r{    "nest2": \{}, contents
   end
 
-  def test_that_empty_lines_trimmed_from_html
+  def test_that_empty_html_lines_not_interpreted_by_markdown
     options = deep_copy(GraphQLDocs::Configuration::GRAPHQLDOCS_DEFAULTS)
     options[:output_dir] = @output_dir
 
@@ -162,5 +162,17 @@ class GeneratorTest < Minitest::Test
     contents = File.read File.join(@output_dir, 'operation', 'query', 'index.html')
 
     assert_match %r{<td>\s+<p>The code of conduct's key</p>\s+</td>}, contents
+  end
+
+  def test_that_non_empty_html_lines_not_interpreted_by_markdown
+    options = deep_copy(GraphQLDocs::Configuration::GRAPHQLDOCS_DEFAULTS)
+    options[:output_dir] = @output_dir
+
+    generator = GraphQLDocs::Generator.new(@results, options)
+    generator.generate
+
+    contents = File.read File.join(@output_dir, 'input_object', 'projectorder', 'index.html')
+
+    assert_match %r{<div class="description-wrapper">\s+<p>The direction in which to order projects by the specified field.</p>\s+</div>}, contents
   end
 end


### PR DESCRIPTION
:disappointed: Third time's a charm?

Looks like I keep swinging and missing on this solution.  Turns out there were more use cases for the trimming than I was aware.  While the prior PR fixed scenarios where we have whitespace at the beginning of a line like so:

```
    <% items.each do |item| %>
```

...it doesn't account for whitespace at the beginning of a line that outputs actual content.  For example:

```
    <%= "test" %>
```

In the above scenario, Markdown would still interpret the 4 spaces at the beginning of the line and improperly modify the structure of the html.

As far as I can tell, we have 2 options.  Either (a) we have a separate renderer for markdown content vs. html content or (b) we only trim html content.

I've put together an implementation for solution (b).  Would love to hear your thoughts.

@gjtorikian 