### PR TITLE
Accept a schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /test/graphql-docs/fixtures/output/
 /.sass-cache/
 /output/
+.byebug_history

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ GraphQLDocs.build(filename: filename)
 
 # or pass in a string
 GraphQLDocs.build(schema: contents)
+
+# or a schema class
+schema = GraphQL::Schema.define do
+  query query_type
+end
+GraphQLDocs.build(schema: schema)
 ```
 
 ## Breakdown

--- a/Rakefile
+++ b/Rakefile
@@ -17,12 +17,15 @@ task default: :test
 Rake::Task[:test].enhance { Rake::Task[:html_proofer].invoke }
 
 desc 'Invoke HTML-Proofer'
-task html_proofer: [:generate_sample] do
-  require 'html-proofer'
-  output_dir = File.join(File.dirname(__FILE__), 'output')
+task :html_proofer do
+  if ENV['CI']
+    Rake::Task[:generate_sample].invoke('https://www.gjtorikian.com/graphql-docs')
+    require 'html-proofer'
+    output_dir = File.join(File.dirname(__FILE__), 'output')
 
-  proofer_options = { disable_external: true, assume_extension: true }
-  HTMLProofer.check_directory(output_dir, proofer_options).run
+    proofer_options = { disable_external: true, assume_extension: true }
+    HTMLProofer.check_directory(output_dir, proofer_options).run
+  end
 end
 
 desc 'Set up a console'

--- a/graphql-docs.gemspec
+++ b/graphql-docs.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'html-proofer', '~> 3.4'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'minitest-focus', '~> 1.1'
-  spec.add_development_dependency 'pry', '~> 0.10.0'
+  spec.add_development_dependency 'pry-byebug', '~> 3.6'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rubocop-github'
   spec.add_development_dependency 'webmock', '~> 2.3'

--- a/lib/graphql-docs.rb
+++ b/lib/graphql-docs.rb
@@ -38,8 +38,8 @@ module GraphQLDocs
 
         schema = File.read(filename)
       else
-        unless schema.is_a?(String)
-          raise TypeError, "Expected `String`, got `#{schema.class}`"
+        if !schema.is_a?(String) && !schema.is_a?(GraphQL::Schema)
+          raise TypeError, "Expected `String` or `GraphQL::Schema`, got `#{schema.class}`"
         end
 
         schema = schema

--- a/lib/graphql-docs.rb
+++ b/lib/graphql-docs.rb
@@ -1,4 +1,4 @@
-# rubocop:disable Style/FileName
+# rubocop:disable Naming/FileName
 require 'graphql-docs/helpers'
 require 'graphql-docs/renderer'
 require 'graphql-docs/configuration'

--- a/lib/graphql-docs/parser.rb
+++ b/lib/graphql-docs/parser.rb
@@ -11,7 +11,12 @@ module GraphQLDocs
 
       @options[:notices] ||= -> (schema_member_path) { [] }
 
-      @schema = GraphQL::Schema.from_definition(schema)
+      if schema.is_a?(GraphQL::Schema)
+        @schema = schema
+      else
+        @schema = GraphQL::Schema.from_definition(schema)
+      end
+
       @processed_schema = {
         operation_types: [],
         mutation_types: [],

--- a/test/graphql-docs/graphql-docs_test.rb
+++ b/test/graphql-docs/graphql-docs_test.rb
@@ -1,4 +1,4 @@
-# rubocop:disable Style/FileName
+# rubocop:disable Naming/FileName
 require 'test_helper'
 
 class GraphQLDocsTest < Minitest::Test

--- a/test/graphql-docs/parser_test.rb
+++ b/test/graphql-docs/parser_test.rb
@@ -28,7 +28,7 @@ class ParserTest < Minitest::Test
     end
 
     results = GraphQLDocs::Parser.new(schema, {}).parse
-    assert_equal "test", results[:operation_types][0][:fields][0][:name]
+    assert_equal 'test', results[:operation_types][0][:fields][0][:name]
     assert_equal "Title paragraph.\n        ```\n        line1\n          line2\n        line3\n        ```", results[:operation_types][0][:fields][0][:description]
   end
 

--- a/test/graphql-docs/parser_test.rb
+++ b/test/graphql-docs/parser_test.rb
@@ -8,6 +8,30 @@ class ParserTest < Minitest::Test
     @results = @parser.parse
   end
 
+  def test_it_accepts_schema_class
+    query_type = GraphQL::ObjectType.define do
+      name 'Query'
+
+      field :test do
+        type types.Int
+        description "Title paragraph.
+        ```
+        line1
+          line2
+        line3
+        ```"
+      end
+    end
+
+    schema = GraphQL::Schema.define do
+      query query_type
+    end
+
+    results = GraphQLDocs::Parser.new(schema, {}).parse
+    assert_equal "test", results[:operation_types][0][:fields][0][:name]
+    assert_equal "Title paragraph.\n        ```\n        line1\n          line2\n        line3\n        ```", results[:operation_types][0][:fields][0][:description]
+  end
+
   def test_types_are_sorted
     names = @results[:object_types].map { |t| t[:name] }
     assert_equal names.sort, names


### PR DESCRIPTION
From https://github.com/gjtorikian/graphql-docs/issues/47#issuecomment-387202189, this PR now allows for a `GraphQL::Schema` to be directly passed in.

cc @tobespangler-bic

Should close #47.