### PR TITLE
Determine correct named root types

### DIFF
--- a/lib/graphql-docs.rb
+++ b/lib/graphql-docs.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Naming/FileName
 require 'graphql-docs/helpers'
 require 'graphql-docs/renderer'
 require 'graphql-docs/configuration'

--- a/lib/graphql-docs/generator.rb
+++ b/lib/graphql-docs/generator.rb
@@ -84,7 +84,7 @@ module GraphQLDocs
     def create_graphql_operation_pages
       graphql_operation_types.each do |query_type|
         metadata = ''
-        if query_type[:name] == 'Query'
+        if query_type[:name] == graphql_root_types['query']
           unless @options[:landing_pages][:query].nil?
             query_landing_page = @options[:landing_pages][:query]
             query_landing_page = File.read(query_landing_page)
@@ -98,7 +98,7 @@ module GraphQLDocs
           end
           opts = default_generator_options(type: query_type)
           contents = @graphql_operation_template.result(OpenStruct.new(opts).instance_eval { binding })
-          write_file('operation', query_type[:name], metadata + contents)
+          write_file('operation', 'query', metadata + contents)
         end
       end
     end

--- a/lib/graphql-docs/helpers.rb
+++ b/lib/graphql-docs/helpers.rb
@@ -21,6 +21,10 @@ module GraphQLDocs
       ::CommonMarker.render_html(string, :DEFAULT).strip
     end
 
+    def graphql_root_types
+      @parsed_schema[:root_types] || []
+    end
+
     def graphql_operation_types
       @parsed_schema[:operation_types] || []
     end

--- a/lib/graphql-docs/parser.rb
+++ b/lib/graphql-docs/parser.rb
@@ -30,6 +30,15 @@ module GraphQLDocs
     end
 
     def parse
+
+      root_types = {}
+      ['query', 'mutation'].each do |operation|
+        unless @schema.root_type_for_operation(operation).nil?
+          root_types[operation] = @schema.root_type_for_operation(operation).name
+        end
+      end
+      @processed_schema[:root_types] = root_types
+
       @schema.types.each_value do |object|
         data = {}
 
@@ -37,7 +46,7 @@ module GraphQLDocs
 
         case object
         when ::GraphQL::ObjectType
-          if object.name == 'Query'
+          if object.name == root_types['query']
             data[:name] = object.name
             data[:description] = object.description
 
@@ -45,7 +54,7 @@ module GraphQLDocs
             data[:fields], data[:connections] = fetch_fields(object.fields, object.name)
 
             @processed_schema[:operation_types] << data
-          elsif object.name == 'Mutation'
+          elsif object.name == root_types['mutation']
             data[:name] = object.name
             data[:description] = object.description
 

--- a/test/graphql-docs/fixtures/named-root-schema.graphql
+++ b/test/graphql-docs/fixtures/named-root-schema.graphql
@@ -1,0 +1,7 @@
+schema {
+  query: RootQuery
+}
+type RootQuery {
+  #Do a thing
+  thing: [String!]!
+}

--- a/test/graphql-docs/generator_test.rb
+++ b/test/graphql-docs/generator_test.rb
@@ -136,7 +136,7 @@ class GeneratorTest < Minitest::Test
   def test_that_named_query_root_generates_fields
     options = deep_copy(GraphQLDocs::Configuration::GRAPHQLDOCS_DEFAULTS)
     options[:output_dir] = @output_dir
-    
+
     generator = GraphQLDocs::Generator.new(@named_root_results, options)
     generator.generate
 

--- a/test/graphql-docs/generator_test.rb
+++ b/test/graphql-docs/generator_test.rb
@@ -24,6 +24,10 @@ class GeneratorTest < Minitest::Test
     @tiny_parser = GraphQLDocs::Parser.new(tiny_schema, {})
     @tiny_results = @tiny_parser.parse
 
+    named_root_schema = File.read(File.join(fixtures_dir, 'named-root-schema.graphql'))
+    @named_root_parser = GraphQLDocs::Parser.new(named_root_schema, {})
+    @named_root_results = @named_root_parser.parse
+
     @output_dir = File.join(fixtures_dir, 'output')
   end
 
@@ -127,6 +131,18 @@ class GeneratorTest < Minitest::Test
     object = File.read File.join(@output_dir, 'object', 'codeofconduct', 'index.html')
 
     assert_match /<div class="field-entry my-4">/, object
+  end
+
+  def test_that_named_query_root_generates_fields
+    options = deep_copy(GraphQLDocs::Configuration::GRAPHQLDOCS_DEFAULTS)
+    options[:output_dir] = @output_dir
+    
+    generator = GraphQLDocs::Generator.new(@named_root_results, options)
+    generator.generate
+
+    object = File.read File.join(@output_dir, 'operation', 'query', 'index.html')
+
+    assert_match /Do a thing/, object
   end
 
   def test_that_broken_yaml_is_caught

--- a/test/graphql-docs/graphql-docs_test.rb
+++ b/test/graphql-docs/graphql-docs_test.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Naming/FileName
 require 'test_helper'
 
 class GraphQLDocsTest < Minitest::Test


### PR DESCRIPTION
Fixes #52.

If the root type names are not the defaults (`Query`, `Mutation`, and the as-yet-unsupported-here `Subscription`) then they don't get correctly pulled into the top-level pages.

@gjtorikian note that I'm not rightly sure why mutations sometimes don't come up either, but I see that they seem to have quite different logic in the code which I don't understand. It's just that, given you're working on a PR in a similar area, I've pushed this earlier than I otherwise might!

Also, I'm not a Ruby guy. This probably needs a thorough look-over!