### PR TITLE
Pass filename through to HTML pipeline

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
 gem 'commonmarker', '~> 0.16', require: false

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 

--- a/graphql-docs.gemspec
+++ b/graphql-docs.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'graphql-docs/version'

--- a/lib/graphql-docs.rb
+++ b/lib/graphql-docs.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'graphql-docs/helpers'
 require 'graphql-docs/renderer'
 require 'graphql-docs/configuration'

--- a/lib/graphql-docs/configuration.rb
+++ b/lib/graphql-docs/configuration.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQLDocs
   module Configuration
     GRAPHQLDOCS_DEFAULTS = {

--- a/lib/graphql-docs/generator.rb
+++ b/lib/graphql-docs/generator.rb
@@ -210,8 +210,9 @@ module GraphQLDocs
         contents.gsub!(/^\s{4}/m, '  ')
       end
 
-      contents = @renderer.render(contents, type: type, name: name)
-      File.write(File.join(path, 'index.html'), contents) unless contents.nil?
+      filename = File.join(path, 'index.html')
+      contents = @renderer.render(contents, type: type, name: name, filename: filename)
+      File.write(filename, contents) unless contents.nil?
     end
   end
 end

--- a/lib/graphql-docs/generator.rb
+++ b/lib/graphql-docs/generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'erb'
 require 'sass'
 

--- a/lib/graphql-docs/helpers.rb
+++ b/lib/graphql-docs/helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQLDocs
   module Helpers
     SLUGIFY_PRETTY_REGEXP = Regexp.new("[^[:alnum:]._~!$&'()+,;=@]+").freeze

--- a/lib/graphql-docs/parser.rb
+++ b/lib/graphql-docs/parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'graphql'
 
 module GraphQLDocs

--- a/lib/graphql-docs/renderer.rb
+++ b/lib/graphql-docs/renderer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'html/pipeline'
 require 'yaml'
 require 'extended-markdown-filter'

--- a/lib/graphql-docs/renderer.rb
+++ b/lib/graphql-docs/renderer.rb
@@ -36,17 +36,17 @@ module GraphQLDocs
       @pipeline = HTML::Pipeline.new(filters, @pipeline_config[:context])
     end
 
-    def render(contents, type: nil, name: nil)
-      opts = { base_url: @options[:base_url] }.merge({ type: type, name: name}).merge(helper_methods)
+    def render(contents, type: nil, name: nil, filename: nil)
+      opts = { base_url: @options[:base_url], output_dir: @options[:output_dir] }.merge({ type: type, name: name, filename: filename}).merge(helper_methods)
 
-      contents = to_html(contents)
+      contents = to_html(contents, context: { filename: filename })
       return contents if @graphql_default_layout.nil?
       opts[:content] = contents
       @graphql_default_layout.result(OpenStruct.new(opts).instance_eval { binding })
     end
 
-    def to_html(string)
-      @pipeline.to_html(string)
+    def to_html(string, context: {})
+      @pipeline.to_html(string, context)
     end
 
     private

--- a/lib/graphql-docs/version.rb
+++ b/lib/graphql-docs/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module GraphQLDocs
   VERSION = '1.4.1'
 end

--- a/test/graphql-docs/generator_test.rb
+++ b/test/graphql-docs/generator_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class GeneratorTest < Minitest::Test

--- a/test/graphql-docs/generator_test.rb
+++ b/test/graphql-docs/generator_test.rb
@@ -5,7 +5,7 @@ class GeneratorTest < Minitest::Test
     def initialize(_, _)
     end
 
-    def render(contents, type: nil, name: nil)
+    def render(contents, type: nil, name: nil, filename: nil)
       to_html(contents)
     end
 

--- a/test/graphql-docs/graphql-docs_test.rb
+++ b/test/graphql-docs/graphql-docs_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class GraphQLDocsTest < Minitest::Test

--- a/test/graphql-docs/parser_test.rb
+++ b/test/graphql-docs/parser_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class ParserTest < Minitest::Test

--- a/test/graphql-docs/renderer_test.rb
+++ b/test/graphql-docs/renderer_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class RendererTest < Minitest::Test

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'graphql-docs'
 


### PR DESCRIPTION
I think I can achieve #51 (relative hrefs) through a mixture of a custom html-pipeline filter and some code in some custom layouts. However, in order to do so I need to know the filename that the file is being written to. This allows me to determine the 'depth' relative to some base path of the current file, and therefore add the right number of `../` entries to get out of there.

This pull request passes the filename through to the pipeline's context (on a per-file basis rather than the overarching pipeline-wide context).

Fixes #51.