### PR TITLE
Add commonmarker by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 source 'https://rubygems.org'
 
-gem 'commonmarker', '~> 0.16', require: false
-gem 'rubocop', require: false
-
 # Specify your gem's dependencies in graphql-docs.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -107,8 +107,6 @@ In your ERB layouts, there are several helper methods you can use. The helper me
 
 To call these methods within templates, you must use the dot notation, such as `<%= slugify.(text) %>`.
 
-For `markdownify`, `CommonMarker` is not enabled by default (because it relies on native code). You will need to add `require 'commonmarker'` if you wish to use it.
-
 ## Configuration
 
 The following options are available:

--- a/graphql-docs.gemspec
+++ b/graphql-docs.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'graphql', '~> 1.6'
 
   # rendering
+  spec.add_dependency 'commonmarker', '~> 0.16'
   spec.add_dependency 'html-pipeline', '~> 2.8'
   spec.add_dependency 'escape_utils',  '~> 1.2'
   spec.add_dependency 'extended-markdown-filter', '~> 0.4'
@@ -37,6 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest-focus', '~> 1.1'
   spec.add_development_dependency 'pry-byebug', '~> 3.6'
   spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rubocop-github'
   spec.add_development_dependency 'webmock', '~> 2.3'
 end

--- a/lib/graphql-docs/helpers.rb
+++ b/lib/graphql-docs/helpers.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+require 'commonmarker'
+
 module GraphQLDocs
   module Helpers
     SLUGIFY_PRETTY_REGEXP = Regexp.new("[^[:alnum:]._~!$&'()+,;=@]+").freeze
@@ -19,7 +22,6 @@ module GraphQLDocs
 
     def markdownify(string)
       return '' if string.nil?
-      return string unless defined?(CommonMarker)
       ::CommonMarker.render_html(string, :DEFAULT).strip
     end
 


### PR DESCRIPTION
There's no point in excluding this, since both `MarkdownFilter` and `markdownify` use it anyway. Commonmarker is safe enough to build on all systems by now.

This REALLY closes #57; #58 was a bust. 