### PR TITLE
Add deprecations to connection fields

### DIFF
--- a/lib/graphql-docs/layouts/includes/connections.html
+++ b/lib/graphql-docs/layouts/includes/connections.html
@@ -13,7 +13,7 @@
 
     <%= include.('notices.html', notices: connection[:notices]) %>
 
-    <p><%= connection[:description] %></p>
+    <p><%= markdownify.(connection[:description]) %></p>
 
     <% unless connection[:arguments].empty? %>
       <%= include.('arguments.html', arguments: connection[:arguments]) %>

--- a/lib/graphql-docs/layouts/includes/connections.html
+++ b/lib/graphql-docs/layouts/includes/connections.html
@@ -4,7 +4,15 @@
   <span id="<%= slugify.(connection[:name]) %>" class="field-name connection-name anchored"><%= connection[:name] %> (<code><a href="<%= base_url %>/<%= connection[:type][:path] %>"><%= connection[:type][:info] %></a></code>)</span>
 
   <div class="description-wrapper">
+    <% if connection[:is_deprecated] %>
+      <div class="deprecation-notice <%= classes[:deprecation_notice] %>">
+        <span class="deprecation-title">Deprecation notice</span>
+        <%= markdownify.(connection[:deprecation_reason]) %>
+      </div>
+    <% end %>
+
     <%= include.('notices.html', notices: connection[:notices]) %>
+
     <p><%= connection[:description] %></p>
 
     <% unless connection[:arguments].empty? %>


### PR DESCRIPTION
Problem
------------
Connection field descriptions are not parsed for markdown and deprecation notices aren't rendered for this particular field type.

Solution
------------
I used similar HTML as found in `graphql-docs/lib/graphql-docs/layouts/includes/fields.html` for rendering deprecation notices and wrapped `connection[:description]` in `markdownify.()`
      