### PR TITLE
Fix incorrect ruby syntax and :notice singular

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ A `notice` has the following options:
 Example of a `notices` proc that adds a notice to the `TeamDiscussion` type:
 
 ```ruby
-options[:notice] = (schema_member_path) -> {
+options[:notices] = ->(schema_member_path) {
   notices = []
 
   if schema_member_path == "TeamDiscussion"


### PR DESCRIPTION
The lambda syntax for the `options[:notices]` example was incorrect, and was setting `:notice` rather than `:notices`, which didn't work.