### PR TITLE
Add event listener to toggle mobile sidebar

### DIFF
--- a/lib/graphql-docs/layouts/default.html
+++ b/lib/graphql-docs/layouts/default.html
@@ -37,7 +37,7 @@
 
       <!-- mobile only -->
       <div id="mobile-header">
-        <a class="menu-button"></a>
+        <a class="menu-button" onclick="document.body.classList.toggle('sidebar-open')"></a>
         <a class="logo" href="<%= base_url.present? ? base_url : '/' %>">
 
         </a>


### PR DESCRIPTION
On mobile widths < 560px, the sidebar is not visible and the menu button did not trigger a change. This `onclick` listener will toggle the existing `sidebar-open` class to reveal or hide the sidebar for mobile users.