### PR TITLE
Fix deprecation on graphql_definition ( Upgrade Graphql to 1.12.x)

### DIFF
--- a/graphql-docs.gemspec
+++ b/graphql-docs.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'graphql', '~> 1.10'
+  spec.add_dependency 'graphql', '~> 1.12'
 
   # rendering
   spec.add_dependency 'commonmarker', '~> 0.16'

--- a/lib/graphql-docs/parser.rb
+++ b/lib/graphql-docs/parser.rb
@@ -217,7 +217,7 @@ module GraphQLDocs
       {
         name: name,
         path: "#{path}/#{slugify(name)}",
-        info: type.graphql_definition
+        info: type.to_type_signature
       }
     end
 

--- a/test/graphql-docs/parser_test.rb
+++ b/test/graphql-docs/parser_test.rb
@@ -49,7 +49,7 @@ class ParserTest < Minitest::Test
     assert_equal %w[deprecated include preview skip], names
 
     preview_directive = @gh_results[:directive_types].find { |t| t[:name] == 'deprecated' }
-    assert_equal %i[FIELD_DEFINITION ENUM_VALUE], preview_directive[:locations]
+    assert_equal %i[FIELD_DEFINITION ENUM_VALUE ARGUMENT_DEFINITION INPUT_FIELD_DEFINITION], preview_directive[:locations]
 
     assert_equal 'Marks an element of a GraphQL schema as no longer supported.', preview_directive[:description]
     reason_arg = preview_directive[:arguments].first


### PR DESCRIPTION
Upgrade graphql to address: 

* https://github.com/rmosolgo/graphql-ruby/pull/3765
* https://github.com/rmosolgo/graphql-ruby/pull/3750 
* 
Fixes :  #88 